### PR TITLE
add displayName: TabGuard

### DIFF
--- a/src/tabguard.coffee
+++ b/src/tabguard.coffee
@@ -21,6 +21,8 @@ focusableElementsList = [
 focusableElementsSelector = focusableElementsList.join()
 
 TabGuard = React.createClass
+  displayName: 'TabGuard'
+
   propTypes:
     className: React.PropTypes.string
 


### PR DESCRIPTION
- `displayName` is needed for enzyme to [find](http://airbnb.io/enzyme/docs/api/ReactWrapper/find.html) component
- TabGuard does not export constructor so this is the only option in enzyme tests